### PR TITLE
export BusPutEvent interface from index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { Bus } from './Bus';
+export { Bus, BusPutEvent } from './Bus';
 export { Event, PublishedEvent } from './Event';


### PR DESCRIPTION
We often need `BusPutEvent` interface in our codebase, so I think it will be prettier if it is directly exported from `index.ts`.
What do you think ?