### PR TITLE
⬆️ Upgrade json-schema-to-ts version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "ajv": "^6.12.6",
-    "json-schema-to-ts": "1.5.0"
+    "json-schema-to-ts": "2.1.1"
   },
   "devDependencies": {
     "@aws-sdk/client-eventbridge": "^3.50.0",

--- a/src/Bus.ts
+++ b/src/Bus.ts
@@ -5,6 +5,7 @@ import type {
   PutEventsResultEntry,
 } from '@aws-sdk/client-eventbridge';
 import { PutEventsCommand } from '@aws-sdk/client-eventbridge';
+import { JSONSchema } from 'json-schema-to-ts';
 
 import { Event } from './Event';
 
@@ -59,7 +60,7 @@ export class Bus {
     );
   }
 
-  computePattern(events: Event<string, Record<string, unknown>>[]): {
+  computePattern(events: Event<string, JSONSchema>[]): {
     source?: string[];
     'detail-type'?: string[];
   } {

--- a/src/Event.test.ts
+++ b/src/Event.test.ts
@@ -20,6 +20,18 @@ jest.useFakeTimers();
 
 describe('Event', () => {
   describe('#construct', () => {
+    const eventBridgeMock = mockClient(EventBridgeClient);
+
+    eventBridgeMock
+      .on(PutEventsCommand)
+      .resolves({ Entries: [{ EventId: '123456' }] });
+
+    const myBus = new Bus({
+      name: 'test',
+      // @ts-expect-error Mocking library mocked client is not type compatible with actual client
+      EventBridge: eventBridgeMock,
+    });
+
     const schema = {
       type: 'object',
       properties: {
@@ -29,24 +41,12 @@ describe('Event', () => {
       additionalProperties: false,
       required: ['attribute'],
     } as const;
-    let myBus: Bus, myEvent: Event<string, typeof schema>;
-    const eventBridgeMock = mockClient(EventBridgeClient);
 
-    beforeAll(() => {
-      eventBridgeMock
-        .on(PutEventsCommand)
-        .resolves({ Entries: [{ EventId: '123456' }] });
-      myBus = new Bus({
-        name: 'test',
-        // @ts-expect-error Mocking library mocked client is not type compatible with actual client
-        EventBridge: eventBridgeMock,
-      });
-      myEvent = new Event({
-        name: 'myEvent',
-        source: 'source',
-        bus: myBus,
-        schema,
-      });
+    const myEvent = new Event({
+      name: 'myEvent',
+      source: 'source',
+      bus: myBus,
+      schema,
     });
 
     afterAll(() => {

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -10,7 +10,7 @@ import { Bus } from './Bus';
 
 const ajv = new Ajv();
 
-export class Event<N extends string, S extends JSONSchema, P = FromSchema<S>> {
+export class Event<N extends string, S extends JSONSchema> {
   private _name: N;
   private _source: string;
   private _bus: Bus;
@@ -77,7 +77,7 @@ export class Event<N extends string, S extends JSONSchema, P = FromSchema<S>> {
     };
   }
 
-  create(event: P): PutEventsRequestEntry {
+  create(event: FromSchema<S>): PutEventsRequestEntry {
     if (!this._validate(event)) {
       throw new Error(
         'Event does not satisfy schema' + JSON.stringify(this._validate.errors),
@@ -91,16 +91,12 @@ export class Event<N extends string, S extends JSONSchema, P = FromSchema<S>> {
     };
   }
 
-  async publish(event: P): Promise<PutEventsResponse> {
+  async publish(event: FromSchema<S>): Promise<PutEventsResponse> {
     return this._bus.put([this.create(event)]);
   }
 }
 
-type GenericEvent = Event<
-  string,
-  Record<string, unknown>,
-  Record<string, unknown>
->;
+type GenericEvent = Event<string, JSONSchema>;
 
 export type PublishedEvent<Event extends GenericEvent> = EventBridgeEvent<
   Event['name'],


### PR DESCRIPTION
Hi @fredericbarthelet 👋

Since v2, json-schema-to-ts now supports an option as secondary input. For the moment, TypeBridge doesn't give the possibility to hydrate such options. I see two possibilities to fix that:

1. Give the possibility to hydrate such options with generic types

```typescript
const myEvent = new Event<"EVENT_NAME", typeof mySchema, FromSchemaOptions>({...})
```

2. Give the possibility to override the inferred type with an overlay

```typescript
type MyOverlay = {
  name: string
}

const myEvent = new Event<MyOverlay, "EVENT_NAME">({...}) // <= Is hard-typing the event name really useful ?

// This way the users can re-use FromSchema with custom options in the Overlay
const myEvent = new Event<FromSchema<typeof mySchema, CustomOptions>, "EVENT_NAME">({...})
```

WDYT ?