### PR TITLE
feat: Enrich put and publish method results with initial command payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/eslint-plugin": "^5.11.0",
     "@typescript-eslint/parser": "^5.11.0",
     "aws-lambda-mock-context": "^3.2.1",
-    "aws-sdk-client-mock": "^0.5.6",
+    "aws-sdk-client-mock": "^2.0.0",
     "eslint": "^8.8.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-jest": "^26.1.0",

--- a/src/Bus.test.ts
+++ b/src/Bus.test.ts
@@ -133,9 +133,9 @@ describe('Bus', () => {
       expect(
         computeEventSize({
           DetailType: 'myType',
-          Detail: JSON.stringify({ property: 'vaalue' }),
+          Detail: JSON.stringify({ property: 'value' }),
         }),
-      ).toBe(27);
+      ).toBe(26);
     });
   });
 

--- a/src/Bus.test.ts
+++ b/src/Bus.test.ts
@@ -1,10 +1,21 @@
-import { chunkEntries, computeEventSize } from './Bus';
+import { Bus, chunkEntries, computeEventSize } from './Bus';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from '@aws-sdk/client-eventbridge';
 
 const smallEntry = {
   Detail: 'small'.repeat(Math.round(25000 / 5)), // ~ 25Kb
 };
 const bigEntry = {
   Detail: 'big'.repeat(Math.round(100000 / 3)), // ~ 100Kb
+};
+const failEntry = {
+  Detail: 'fail',
+};
+const successEntry = {
+  Detail: 'success',
 };
 
 const cases = [
@@ -60,6 +71,63 @@ const cases = [
 ];
 
 describe('Bus', () => {
+  describe('#put', () => {
+    const eventBridgeClientMock = mockClient(EventBridgeClient);
+    const bus = new Bus({
+      name: 'testBus',
+      // @ts-expect-error Mocking library mocked client is not type compatible with actual client
+      EventBridge: eventBridgeClientMock,
+    });
+    beforeEach(() => {
+      eventBridgeClientMock.reset();
+    });
+    it('should return events command payload with results', () => {
+      const testCase = [
+        failEntry,
+        successEntry,
+        successEntry,
+        failEntry,
+        successEntry,
+        failEntry,
+        successEntry,
+      ];
+      eventBridgeClientMock.on(PutEventsCommand).resolves({
+        FailedEntryCount: 3,
+        Entries: [
+          { ErrorCode: '12', ErrorMessage: 'There was an error' },
+          { EventId: '97a200f1-6919-4619-ac2f-e0026ebb15b7' },
+          { EventId: 'e4c40e6a-1fc0-4f5a-82b3-c6c284d772ca' },
+          { ErrorCode: '13', ErrorMessage: 'There was an error' },
+          { EventId: '1cdf5682-6f5c-4c21-b922-f83d06447952' },
+          { ErrorCode: '14', ErrorMessage: 'There was an error' },
+          { EventId: '9039f372-d810-474b-9741-b369394cefef' },
+        ],
+      });
+      const failEntryResultBuilder = (code: string) => ({
+        ErrorCode: code,
+        ErrorMessage: 'There was an error',
+        Detail: 'fail',
+        EventBusName: 'testBus',
+      });
+      const successEntryResultBuilder = (id: string) => ({
+        EventId: id,
+        Detail: 'success',
+        EventBusName: 'testBus',
+      });
+      expect(bus.put(testCase)).resolves.toEqual({
+        FailedEntryCount: 3,
+        Entries: [
+          failEntryResultBuilder('12'),
+          successEntryResultBuilder('97a200f1-6919-4619-ac2f-e0026ebb15b7'),
+          successEntryResultBuilder('e4c40e6a-1fc0-4f5a-82b3-c6c284d772ca'),
+          failEntryResultBuilder('13'),
+          successEntryResultBuilder('1cdf5682-6f5c-4c21-b922-f83d06447952'),
+          failEntryResultBuilder('14'),
+          successEntryResultBuilder('9039f372-d810-474b-9741-b369394cefef'),
+        ],
+      });
+    });
+  });
   describe('#computeEventSize', () => {
     it('should compute event size', () => {
       expect(

--- a/src/Event.test.ts
+++ b/src/Event.test.ts
@@ -54,12 +54,19 @@ describe('Event', () => {
     });
 
     it('should allow publishing an event', async () => {
-      expect(
-        await myEvent.publish({
-          attribute: 'hello',
-          numberAttribute: 12,
-        }),
-      ).toHaveProperty('Entries', [{ EventId: '123456' }]);
+      const eventPayload = {
+        attribute: 'hello',
+        numberAttribute: 12,
+      };
+      expect(await myEvent.publish(eventPayload)).toHaveProperty('Entries', [
+        {
+          EventId: '123456',
+          DetailType: 'myEvent',
+          Detail: JSON.stringify(eventPayload),
+          EventBusName: 'test',
+          Source: 'source',
+        },
+      ]);
     });
 
     it('should fail with the use of validationMiddleware on wrong event', () => {

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -1,7 +1,7 @@
 import Ajv from 'ajv';
 import type {
   PutEventsRequestEntry,
-  PutEventsResponse,
+  PutEventsResultEntry,
 } from '@aws-sdk/client-eventbridge';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import type { EventBridgeEvent } from 'aws-lambda';
@@ -91,7 +91,10 @@ export class Event<N extends string, S extends JSONSchema> {
     };
   }
 
-  async publish(event: FromSchema<S>): Promise<PutEventsResponse> {
+  async publish(event: FromSchema<S>): Promise<{
+    FailedEntryCount?: number;
+    Entries?: (PutEventsRequestEntry & PutEventsResultEntry)[];
+  }> {
     return this._bus.put([this.create(event)]);
   }
 }


### PR DESCRIPTION
This feature is particularly handy to avoid having to deal with indexes to know which entry failed.